### PR TITLE
Fix Indeterminate computed property

### DIFF
--- a/addon/components/bootstrap-switch.js
+++ b/addon/components/bootstrap-switch.js
@@ -111,6 +111,8 @@ export default Ember.Component.extend({
     var checked = this.get('checked');
     if (type !== 'radio' && (checked === undefined || checked === null)) {
       return true;
+    }else{
+      return false;
     }
   }), // :indeterminate
 


### PR DESCRIPTION
indeterminate computed property should update to false when observed value is no longer undefined

I have the checkboxes set to a value that is updated on resolution of a promise. so initial state is undefined. If the updated value is false, the indeterminate state remained visually. Only if the value was changed to true did it change. This fixed the issue for me
