### PR TITLE
Removed didInitAttrs deprecation warning by replacing with init hook

### DIFF
--- a/addon/components/bootstrap-switch.js
+++ b/addon/components/bootstrap-switch.js
@@ -116,10 +116,10 @@ export default Ember.Component.extend({
 
 
   // Need to keep track of the initial attributes for 'didRender()'
-  didInitAttrs( attrs ){
+  init(){
     this._super(...arguments);
-    this.set('_initialAttrs', attrs.attrs);
-  }, // didInitAttrs()
+    this.set('_initialAttrs', this.get('attrs'));
+  }, // init()
 
 
 


### PR DESCRIPTION
@Panman8201 Fixes https://github.com/Panman8201/ember-bootstrap-switch/issues/13
